### PR TITLE
fix imports of eve_sqlalchemy extension in example

### DIFF
--- a/examples/settings.py
+++ b/examples/settings.py
@@ -6,7 +6,7 @@
     we need to define the schema using the registerSchema decorator.
 
 """
-from eve.io.sql.decorators import registerSchema
+from eve_sqlalchemy.decorators import registerSchema
 from tables import People, Invoices
 
 registerSchema('people')(People)

--- a/examples/sqla_example.py
+++ b/examples/sqla_example.py
@@ -1,5 +1,6 @@
 from eve import Eve
-from eve.io.sql import SQL, ValidatorSQL
+from eve_sqlalchemy import SQL
+from eve_sqlalchemy.validation import ValidatorSQL
 from tables import People, Base
 
 app = Eve(validator=ValidatorSQL, data=SQL)


### PR DESCRIPTION
The imports of the example has not been updated for the new eve-sqlalchemy extention.

cheers
Hannes