### PR TITLE
add missing column '_etag' for CommonColumns in examples

### DIFF
--- a/examples/tables.py
+++ b/examples/tables.py
@@ -23,6 +23,7 @@ class CommonColumns(Base):
     __abstract__ = True
     _created = Column(DateTime, default=func.now())
     _updated = Column(DateTime, default=func.now(), onupdate=func.now())
+    _etag = Column(String(40))
 
     @hybrid_property
     def _id(self):


### PR DESCRIPTION
When we send a POST request to the Server from examples, it responds:

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/dist-packages/Eve-0.5.1-py2.7.egg/eve/endpoints.py", line 54, in collections_endpoint
    response = post(resource)
  File "/usr/local/lib/python2.7/dist-packages/Eve-0.5.1-py2.7.egg/eve/methods/common.py", line 237, in rate_limited
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/Eve-0.5.1-py2.7.egg/eve/auth.py", line 60, in decorated
    return f(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/Eve-0.5.1-py2.7.egg/eve/methods/common.py", line 794, in decorated
    r = f(resource, **combined_args)
  File "/usr/local/lib/python2.7/dist-packages/Eve-0.5.1-py2.7.egg/eve/methods/post.py", line 40, in post
    return post_internal(resource, payl, skip_validation=False)
  File "/usr/local/lib/python2.7/dist-packages/Eve-0.5.1-py2.7.egg/eve/methods/post.py", line 228, in post_internal
    ids = app.data.insert(resource, documents)
  File "build/bdist.linux-x86_64/egg/eve_sqlalchemy/__init__.py", line 214, in insert
    model_instance = model(**document)
  File "<string>", line 4, in __init__
    
  File "/usr/local/lib/python2.7/dist-packages/SQLAlchemy-0.9.8-py2.7.egg/sqlalchemy/orm/state.py", line 260, in _initialize_instance
    return manager.original_init(*mixed[1:], **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/SQLAlchemy-0.9.8-py2.7.egg/sqlalchemy/ext/declarative/base.py", line 525, in _declarative_constructor
    (k, cls_.__name__))
TypeError: '_etag' is an invalid keyword argument for People
```

Therefore, I'm wondering whether the column '_etag' is missing.