### PR TITLE
The trivial example should fit in one file.

### DIFF
--- a/docs/trivial.rst
+++ b/docs/trivial.rst
@@ -1,0 +1,29 @@
+Create a file, called trivial.py, and inclue the following:
+
+.. literalinclude:: ../examples/trivial.py
+
+Run this command to start the server:
+
+    python trivial.py
+
+Open the following in your browser to confirm that the server is serving: 
+
+    http://127.0.0.1:5000/
+
+You will see something like this:
+
+    <resource>
+    <link rel="child" href="invoices" title="invoices"/>
+    <link rel="child" href="people" title="people"/>
+    </resource>
+
+Now try the people URL:
+
+    http://127.0.0.1:5000/people
+
+You will see the three records we preloaded.
+
+    <resource href="people" title="people">
+    <link rel="parent" href="/" title="home"/><_meta><max_results>25</max_results><page>1</page><total>3</total></_meta><resource><_created/><_etag/><_updated>Sun, 22 Feb 2015 16:28:00 GMT</_updated><firstname>George</firstname><fullname>George Washington</fullname><id>1</id><lastname>Washington</lastname></resource>
+    ... etc ...
+

--- a/examples/trivial.py
+++ b/examples/trivial.py
@@ -1,0 +1,64 @@
+''' Trivial Eve-SQLAlchemy example. '''
+# SQLAlchemy Imports
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import column_property
+from sqlalchemy import (
+    Column,
+    String,
+    Integer,
+    )
+
+# Eve imports
+from eve import Eve
+from eve_sqlalchemy import SQL
+from eve_sqlalchemy.validation import ValidatorSQL
+
+# Eve-SQLAlchemy imports
+from eve_sqlalchemy.decorators import registerSchema
+
+Base = declarative_base()
+
+class People(Base):
+    __tablename__ = 'people'
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    firstname = Column(String(80))
+    lastname = Column(String(120))
+    fullname = column_property(firstname + " " + lastname)
+
+    @classmethod
+    def from_tuple(cls, data):
+        """Helper method to populate the db"""
+        return cls(firstname=data[0], lastname=data[1])
+
+registerSchema('people')(People)
+
+SETTINGS = {
+    'DEBUG': True,
+    'SQLALCHEMY_DATABASE_URI':'sqlite://',
+    'DOMAIN': {
+        'people': People._eve_schema['people'],
+        }
+}
+
+app = Eve(auth=None, settings=SETTINGS, validator=ValidatorSQL, data=SQL)
+
+# bind SQLAlchemy
+db = app.data.driver
+Base.metadata.bind = db.engine
+db.Model = Base
+db.create_all()
+
+# Insert some example data in the db
+
+test_data = [
+(u'George', u'Washington'),
+(u'John', u'Adams'),
+(u'Thomas', u'Jefferson'),
+]
+
+if not db.session.query(People).count():
+    for item in test_data:
+        db.session.add(People.from_tuple(item))
+    db.session.commit()
+
+app.run(debug=True, use_reloader=False) # using reloaded will destory in-memory sqlite db


### PR DESCRIPTION
Here is a proposed trivial example to address issue #17.

The idea behind this addition is to allow a developer trying out eve-sqlalchemy to create and test an example using a single source file in less than two minutes.