### PR TITLE
Return everything as dicts instead of SQLAResult

### DIFF
--- a/eve_sqlalchemy/__init__.py
+++ b/eve_sqlalchemy/__init__.py
@@ -20,8 +20,8 @@ from sqlalchemy.orm.collections import InstrumentedList
 from eve.io.base import DataLayer, ConnectionException, BaseJSONEncoder
 from eve.utils import config, debug_error_message, str_to_date
 from .parser import parse, parse_dictionary, ParseError, sqla_op, parse_sorting
-from .structures import SQLAResult, SQLAResultCollection
-from .utils import dict_update, validate_filters
+from .structures import SQLAResultCollection
+from .utils import dict_update, validate_filters, sqla_object_to_dict
 
 
 db = flask_sqlalchemy.SQLAlchemy()
@@ -192,14 +192,14 @@ class SQL(DataLayer):
                 or isinstance(lookup.get(config.ID_FIELD), InstrumentedList):
             # very dummy way to get the related object
             # that commes from embeddable parameter
-            return SQLAResult(lookup.get(config.ID_FIELD), fields)
+            return sqla_object_to_dict(lookup.get(config.ID_FIELD), fields)
         else:
             filter_ = self.combine_queries(filter_,
                                            parse_dictionary(lookup, model))
             query = self.driver.session.query(model)
             document = query.filter(*filter_).first()
 
-        return SQLAResult(document, fields) if document else None
+        return sqla_object_to_dict(document, fields) if document else None
 
     def find_one_raw(self, resource, _id):
         raise NotImplementedError

--- a/eve_sqlalchemy/tests/delete.py
+++ b/eve_sqlalchemy/tests/delete.py
@@ -124,7 +124,7 @@ class TestDeleteSQL(TestBaseSQL):
         # verify that the only document retrieved is referencing the correct
         # parent document
         response, status = self.get('users/%s/invoices' % fake_person_id)
-        person_id = response[self.app.config['ITEMS']][1]['people']['_id']
+        person_id = response[self.app.config['ITEMS']][1]['people']
         self.assertEqual(person_id, fake_person_id)
 
         # delete all documents at the sub-resource endpoint

--- a/eve_sqlalchemy/tests/get.py
+++ b/eve_sqlalchemy/tests/get.py
@@ -530,7 +530,7 @@ class TestGetSQL(TestBaseSQL):
         self.assertEqual(len(response['_items']), 2)
         self.assertEqual(len(response['_links']), 2)
         # which links to the right contact
-        self.assertEqual(response['_items'][1]['people']['_id'],
+        self.assertEqual(response['_items'][1]['people'],
                          fake_person._id)
 
         _db.session.rollback()
@@ -816,7 +816,7 @@ class TestGetItem(TestBaseSQL):
         response, status = self.get('users/%s/invoices/%s' %
                                     (fake_person._id, fake_invoice._id))
         self.assert200(status)
-        self.assertEqual(response['people']['_id'], fake_person._id)
+        self.assertEqual(response['people'], fake_person._id)
         self.assertEqual(response['_id'], fake_invoice._id)
 
         _db.session.rollback()

--- a/eve_sqlalchemy/tests/sql.py
+++ b/eve_sqlalchemy/tests/sql.py
@@ -12,7 +12,7 @@ from eve.utils import str_to_date
 from eve_sqlalchemy.tests.test_sql_tables import People
 from eve_sqlalchemy.parser import parse, parse_dictionary, ParseError, sqla_op,\
         parse_sorting
-from eve_sqlalchemy.structures import SQLAResultCollection, SQLAResult
+from eve_sqlalchemy.structures import SQLAResultCollection
 from eve_sqlalchemy import SQL
 
 
@@ -164,24 +164,6 @@ class TestSQLStructures(TestCase):
                        'prog', '_etag']
         self.known_resource_count = 101
         self.max_results = 25
-
-    def test_sql_result_keys(self):
-        r = SQLAResult(self.person, self.fields)
-        self.assertEqual(r.keys(), self.fields)
-        self.assertEqual(len(r), len(self.fields))
-        self.assertTrue('prog' in r.keys())
-
-    def test_sql_result_get(self):
-        r = SQLAResult(self.person, self.fields)
-        self.assertEqual(r['firstname'], 'douglas')
-        self.assertRaises(KeyError, lambda r: r['shouldNotExist'], r)
-
-    def test_sql_result_set(self):
-        r = SQLAResult(self.person, self.fields)
-        r['dummy'] = 5
-        self.assertTrue('dummy' in r.keys())
-        self.assertEqual(len(r), len(self.fields))
-        self.assertEqual(r['dummy'], 5)
 
     def test_sql_collection(self):
         self.setupDB()

--- a/eve_sqlalchemy/utils.py
+++ b/eve_sqlalchemy/utils.py
@@ -8,8 +8,10 @@
 
 """
 
+import copy
 import collections
 from eve.utils import config
+from sqlalchemy.ext.declarative.api import DeclarativeMeta
 
 
 def dict_update(d, u):
@@ -31,3 +33,35 @@ def validate_filters(where, resource):
             if key not in allowed:
                 return "filter on '%s' not allowed" % key
     return None
+
+
+def sqla_object_to_dict(obj, fields):
+    """ Creates a dict containing copies of the requested fields from the
+    SQLAlchemy query result """
+    if config.LAST_UPDATED not in fields:
+        fields.append(config.LAST_UPDATED)
+    if config.DATE_CREATED not in fields:
+        fields.append(config.DATE_CREATED)
+    if config.ETAG not in fields \
+            and getattr(config, 'IF_MATCH', True):
+        fields.append(config.ETAG)
+
+    result = {}
+    for field in fields:
+        try:
+            val = obj.__getattribute__(field)
+            # is this field another SQLalchemy object, or a list of SQLalchemy objects?
+            if isinstance(val.__class__, DeclarativeMeta):
+                result[field] = getattr(val, config.ID_FIELD)
+            elif isinstance(val, list) and len(val) > 0 \
+                    and isinstance(val[0].__class__, DeclarativeMeta):
+                result[field] = [getattr(x, config.ID_FIELD) for x in val]
+            else:
+                # If integral type, just copy it
+                result[field] = copy.copy(val)
+        except AttributeError:
+            # Ignore if the requested field does not exist
+            # (may be wrong embedding parameter)
+            pass
+
+    return result


### PR DESCRIPTION
As Eve is ignorant of how we return objects(from find, find_one) it manipulates objects as if they were dicts which are independent of the database. SQLAResult propagates all changes to the database. This creates many issues and might create even more in the future. 

See also issue #11

1. As the SQLAResult objects don't know about embedding or projection both these features don't work at all.
2. Some requests fail when updating etags because the custom json serializer is not used when calculating etags and SQLAResult objects can't be serialized. (This is also why unit tests fail, an easy way to see the problem).
3. Requests to one resource sometimes return objects of a different resource, when those where loaded during hooks.
4. Hooks which have an original and updated parameter don't work. As every object is attached to the database both parameters will be the same.

Also with dicts we don't need jsonify functions at all, which simplifies code of models.

This commit will remove the SQLAResult class and thereby fix all of these issues.