### PR TITLE
Removed jsonify functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Patches and Contributions
 - Jacopo Sabbatini
 - Nicola Iarocci
 - Peter Zinng
+- Conrad Burchert

--- a/eve_sqlalchemy/__init__.py
+++ b/eve_sqlalchemy/__init__.py
@@ -44,19 +44,11 @@ class SQLAJSONDecoder(json.JSONDecoder):
             return rv
 
 
-class SQLAJSONEncoder(BaseJSONEncoder):
-    def default(self, obj):
-        if hasattr(obj, 'jsonify'):  # probably relationship
-            return obj.jsonify()
-        return super(SQLAJSONEncoder, self).default(obj)
-
-
 class SQL(DataLayer):
     """
     SQLAlchemy data access layer for Eve REST API.
     """
     json_decoder_cls = SQLAJSONDecoder
-    json_encoder_class = SQLAJSONEncoder
     driver = db
     serializers = {'datetime': str_to_date}
 

--- a/eve_sqlalchemy/tests/test_sql_tables.py
+++ b/eve_sqlalchemy/tests/test_sql_tables.py
@@ -37,14 +37,6 @@ class CommonColumns(Base):
         self._etag = h.hexdigest()
         super(CommonColumns, self).__init__(*args, **kwargs)
 
-    def jsonify(self):
-        relationships = inspect(self.__class__).relationships.keys()
-        mapper = inspect(self)
-        attrs = [a.key for a in mapper.attrs if
-                 a.key not in relationships
-                 and a.key not in mapper.expired_attributes]
-        return dict([(c, getattr(self, c, None)) for c in attrs])
-
 
 @registerSchema('people')
 class People(CommonColumns):

--- a/examples/tables.py
+++ b/examples/tables.py
@@ -31,18 +31,6 @@ class CommonColumns(Base):
         """
         return self.id
 
-    def jsonify(self):
-        """
-        Used to dump related objects to json
-        """
-        relationships = inspect(self.__class__).relationships.keys()
-        mapper = inspect(self)
-        attrs = [a.key for a in mapper.attrs if \
-                a.key not in relationships \
-                and not a.key in mapper.expired_attributes]
-        attrs += [a.__name__ for a in inspect(self.__class__).all_orm_descriptors if a.extension_type is hybrid.HYBRID_PROPERTY]
-        return dict([(c, getattr(self, c, None)) for c in attrs])
-
 
 class People(CommonColumns):
     __tablename__ = 'people'


### PR DESCRIPTION
The jsonify functions are not needed anymore since dict can be
serialized without a special handler and we return dicts since commit
c68c4fb25e98831060112e1ecab58c792cd243a2