### PR TITLE
use the id_field column from the config

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -360,3 +360,48 @@ which produces order by expression:
 .. _SQLAlchemy internals: http://docs.sqlalchemy.org/en/latest/orm/internals.html
 .. _SQLAlchemy ORDER BY: http://docs.sqlalchemy.org/en/latest/core/sqlelement.html#sqlalchemy.sql.expression.nullsfirst
 .. _`Eve Authentication`: http://python-eve.org/authentication.html#token-based-authentication
+
+How to adjust the primary column name
+----------------------
+
+Eve use the `_id` column as primary id field. This is the default value of the MongoDB database.
+In SQL, it much more common to call this column just `id`. You can do that with the following
+change in your `settings.py`:
+
+.. code-block:: python
+
+    # -*- coding: utf-8 -*-
+
+    ID_FIELD = 'id'
+    ITEM_LOOKUP_FIELD = ID_FIELD
+
+    registerSchema('people')(People)
+
+    DOMAIN = {
+        'people': People._eve_schema['people'],
+    }
+
+    DOMAIN[table].update({
+        'id_field': ID_FIELD,
+	'item_lookup_field': ID_FIELD,
+    }
+
+ It's also possible to overwrite Eve default setting directly:
+
+ .. code-block:: python
+
+
+    # -*- coding: utf-8 -*-
+
+    from eve.utils import config
+
+    ID_FIELD = 'id'
+    ITEM_LOOKUP_FIELD = ID_FIELD
+    config.ID_FIELD = ID_FIELD
+    config.ITEM_LOOKUP_FIELD = ID_FIELD
+
+    registerSchema('people')(People)
+
+    DOMAIN = {
+        'people': People._eve_schema['people'],
+    }

--- a/eve_sqlalchemy/__init__.py
+++ b/eve_sqlalchemy/__init__.py
@@ -206,17 +206,16 @@ class SQL(DataLayer):
             model_instance = model(**document)
             self.driver.session.add(model_instance)
             self.driver.session.commit()
-            # TODO: respect eve ID_FIELD
-            id_ = getattr(model_instance, '_id')
-            document['_id'] = id_
-            rv.append(id_)
+            id_field = getattr(model_instance, self.driver.app.config['ID_FIELD'])
+            document['_id'] = id_field
+            rv.append(id_field)
         return rv
 
     def replace(self, resource, id_, document, original):
         model, filter_, fields_, _ = self._datasource_ex(resource, [])
-        # TODO: respect eve ID_FIELD
+        id_field = self.driver.app.config['ID_FIELD']
         filter_ = self.combine_queries(filter_,
-                                       parse_dictionary({'_id': id_}, model))
+                                       parse_dictionary({id_field: id_}, model))
         query = self.driver.session.query(model)
 
         # Find and delete the old object
@@ -234,9 +233,9 @@ class SQL(DataLayer):
 
     def update(self, resource, id_, updates, original):
         model, filter_, _, _ = self._datasource_ex(resource, [])
-        # TODO: respect eve ID_FIELD
+        id_field = self.driver.app.config['ID_FIELD']
         filter_ = self.combine_queries(filter_,
-                                       parse_dictionary({'_id': id_}, model))
+                                       parse_dictionary({id_field: id_}, model))
         query = self.driver.session.query(model)
         model_instance = query.filter(*filter_).first()
         if model_instance is None:

--- a/eve_sqlalchemy/decorators.py
+++ b/eve_sqlalchemy/decorators.py
@@ -52,8 +52,7 @@ class registerSchema(object):
                 'schema': {},
                 'datasource': {'source': cls_.__name__},
                 'item_lookup': True,
-                # TODO: Make these respect the ID_FIELD config of Eve
-                'item_lookup_field': '_id',
+                'item_lookup_field': config.ID_FIELD,
                 'item_url': 'regex("[0-9]+")'
             }
         }


### PR DESCRIPTION
Use the ID_FIELD configuration key instead of the hardcoded
`_id` value.

Since registerSchema() is called during the configuration init, it
cannot access an initialized config object.
That's why we must:

- overwrite the eve.utils.config key directly
- or adjust _eve_schema() result