### PR TITLE
add support for PostgreSQL JSON type

### DIFF
--- a/eve_sqlalchemy/decorators.py
+++ b/eve_sqlalchemy/decorators.py
@@ -10,6 +10,7 @@ from sqlalchemy.sql import expression
 from sqlalchemy.ext import hybrid
 from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy import types, inspect
+import sqlalchemy.dialects.postgresql
 from sqlalchemy import schema as sqla_schema
 from eve.utils import config
 
@@ -24,7 +25,8 @@ sqla_type_mapping = {types.Integer: 'integer',
                      types.Boolean: 'boolean',
                      types.Date: 'datetime',
                      types.DateTime: 'datetime',
-                     types.DATETIME: 'datetime'}
+                     types.DATETIME: 'datetime',
+                     sqlalchemy.dialects.postgresql.JSON: 'json'}
 # TODO: Add the remaining sensible SQL types
 
 

--- a/eve_sqlalchemy/tests/test_validation.py
+++ b/eve_sqlalchemy/tests/test_validation.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import eve_sqlalchemy.validation
+
+import unittest
+
+
+class TestValidator(unittest.TestCase):
+    def setUp(self):
+        schemas = {
+            'a_json': {
+                'type': 'json',
+            },
+            'a_objectid': {
+                'type': 'objectid',
+            },
+        }
+        self.validator = eve_sqlalchemy.validation.ValidatorSQL(schemas)
+
+    def test_type_json(self):
+        self.validator.validate_update(
+            {'a_json': None}, None)
+
+    def test_type_objectid(self):
+        self.validator.validate_update(
+            {'a_objectid': ''}, None)

--- a/eve_sqlalchemy/validation.py
+++ b/eve_sqlalchemy/validation.py
@@ -94,3 +94,11 @@ class ValidatorSQL(Validator):
         This field doesn't have a meaning in SQL
         """
         pass
+
+    def _validate_type_json(self, field, value):
+        """ Enables validation for `json` schema attribute.
+
+        :param field: field name.
+        :param value: field value.
+        """
+        pass


### PR DESCRIPTION
With this change, it's now possible to push JSON in a JSON field. For
example, in this example, the struct file has the type JSON.

```
POST http://127.0.0.1:5000/notifications
Content-Type: application/json

[{"environment_id":"ae7d4ed8-41b4-0206-6aad-0074c0f5b6f1","struct":{"type":"gerrit","server":"somewhere","account":"bob","port":29418}}]
```

Without this change, the validator will fail because it don't know about
JSON. It will expect a string instead, which is the default type.

This patch requires the following patch:
https://github.com/nicolaiarocci/cerberus/pull/79