### PR TITLE
support the Python-Eve generic sorting syntax

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -363,6 +363,12 @@ which produces order by expression:
 
    people.lastname DESC NULLS LAST
 
+You can also support the following python-Eve syntax:
+
+.. code-block:: console
+
+    http://127.0.0.1:5000/people?sort=lastname,-created_at
+
 How to adjust the primary column name
 -------------------------------------
 

--- a/eve_sqlalchemy/__init__.py
+++ b/eve_sqlalchemy/__init__.py
@@ -8,7 +8,6 @@
 
 __version__ = '0.1-dev'
 
-import ast
 import simplejson as json
 import flask.ext.sqlalchemy as flask_sqlalchemy
 
@@ -21,7 +20,7 @@ from eve.io.base import DataLayer
 from eve.utils import config, debug_error_message, str_to_date
 from .parser import parse, parse_dictionary, ParseError, sqla_op, parse_sorting
 from .structures import SQLAResultCollection
-from .utils import dict_update, validate_filters, sqla_object_to_dict
+from .utils import dict_update, validate_filters, sqla_object_to_dict, extract_sort_arg
 
 
 db = flask_sqlalchemy.SQLAlchemy()
@@ -120,9 +119,7 @@ class SQL(DataLayer):
         :param req: a :class:`ParsedRequest`instance.
         :param sub_resource_lookup: sub-resource lookup from the endpoint url.
         """
-        args = {
-            'sort': ast.literal_eval(req.sort) if req.sort else None
-        }
+        args = {'sort': extract_sort_arg(req)}
 
         client_projection = self._client_projection(req)
         client_embedded = self._client_embedded(req)

--- a/eve_sqlalchemy/tests/utils.py
+++ b/eve_sqlalchemy/tests/utils.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from eve_sqlalchemy.utils import extract_sort_arg
+
+from eve_sqlalchemy.tests import TestBaseSQL
+
+import mock
+
+
+class TestUtils(TestBaseSQL):
+
+    def test_extract_sort_arg_standard(self):
+        req = mock.Mock()
+        req.sort = 'created_at,-name'
+        self.assertEqual(extract_sort_arg(req), [['created_at'], ['name', -1]])
+
+    def test_extract_sort_arg_sqlalchemy(self):
+        req = mock.Mock()
+        req.sort = '[("created_at", -1, "nullstart")]'
+        self.assertEqual(extract_sort_arg(req), [('created_at', -1, 'nullstart')])
+
+    def test_extract_sort_arg_null(self):
+        req = mock.Mock()
+        req.sort = ''
+        self.assertEqual(extract_sort_arg(req), None)

--- a/eve_sqlalchemy/utils.py
+++ b/eve_sqlalchemy/utils.py
@@ -8,8 +8,11 @@
 
 """
 
-import copy
+import ast
 import collections
+import copy
+import re
+
 from eve.utils import config
 from sqlalchemy.ext.declarative.api import DeclarativeMeta
 
@@ -82,3 +85,19 @@ def sqla_object_to_dict(obj, fields):
             pass
 
     return result
+
+
+def extract_sort_arg(req):
+    if req.sort:
+        if re.match('^[-,\w]+$', req.sort):
+            arg = []
+            for s in req.sort.split(','):
+                if s.startswith('-'):
+                    arg.append([s[1:], -1])
+                else:
+                    arg.append([s])
+            return arg
+        else:
+            return ast.literal_eval(req.sort)
+    else:
+        return None

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist=py27,pep8
 [testenv]
 deps=
     pytest
+    mock
     git+git://github.com/nicolaiarocci/eve.git@develop#egg=Eve-0.5-dev
 commands=py.test {posargs}
 


### PR DESCRIPTION
Add support of the python Eve sorting syntax:

    $ curl -i http://eve-demo.herokuapp.com/people?sort=city,-lastname