### PR TITLE
PUT must drop/recreate item in the same transaction

### DIFF
--- a/eve_sqlalchemy/__init__.py
+++ b/eve_sqlalchemy/__init__.py
@@ -207,7 +207,6 @@ class SQL(DataLayer):
         if old_model_instance is None:
             abort(500, description=debug_error_message('Object not existent'))
         self.driver.session.delete(old_model_instance)
-        self.driver.session.commit()
 
         # create and insert the new one
         model_instance = model(**document)

--- a/eve_sqlalchemy/tests/__init__.py
+++ b/eve_sqlalchemy/tests/__init__.py
@@ -95,6 +95,7 @@ class TestBaseSQL(TestMinimal):
 
     def setupDB(self):
         self.connection = self.app.data.driver
+        self.connection.session.execute('pragma foreign_keys=on')
         self.connection.drop_all()
         self.connection.create_all()
         self.bulk_insert()

--- a/eve_sqlalchemy/tests/put.py
+++ b/eve_sqlalchemy/tests/put.py
@@ -96,6 +96,21 @@ class TestPutSQL(TestBaseSQL):
         db_value = self.compare_put_with_get(field, r)
         self.assertEqual(db_value, test_value)
 
+    def test_put_with_fk_constraint(self):
+        # notes.people_id FK should not block the PUT on
+        # /people/1
+        headers = [('Content-Type', 'application/json')]
+        data = json.dumps([{'people_id': 1, 'content': 'blabla'}])
+        r = self.test_client.post('/notes', data=data,
+                                  headers=headers)
+        self.assert201(r.status_code)
+        field = "firstname"
+        test_value = "Douglas"
+        changes = {field: test_value}
+        _, status = self.put(self.item_id_url, data=changes,
+                             headers=[('If-Match', self.item_etag)])
+        self.assert200(status)
+
     def test_put_with_post_override(self):
         # POST request with PUT override turns into a PUT
         field = "firstname"

--- a/eve_sqlalchemy/tests/test_sql_tables.py
+++ b/eve_sqlalchemy/tests/test_sql_tables.py
@@ -53,6 +53,13 @@ class People(CommonColumns):
         return cls(firstname=data[0], lastname=data[1], prog=data[2])
 
 
+@registerSchema('notes')
+class Notes(CommonColumns):
+    __tablename__ = 'notes'
+    people_id = Column(Integer, ForeignKey('people._id'), nullable=False)
+    content = Column(String(120))
+
+
 @registerSchema('invoices')
 class Invoices(CommonColumns):
     __tablename__ = 'invoices'


### PR DESCRIPTION
So far, PUT was calling replace() to drop, commit, recreate the item.
By doing this, we can get the situation where the initial drop break
the foreign keys of the other tables.
Instead, if we do the drop/recreate in the same transaction, the
constraint engine will ignore the unstable situation.

This commit extend the code coverage:
- enable SQLite FK constrain check. We use 'pragma foreign_keys=on'
  to do that.
- create a new notes table with a FK on the people._id key.

See: https://www.sqlite.org/pragma.html