### PR TITLE
New constructor that pass a reference to eve when initializing the auth object 

### DIFF
--- a/eve_sqlalchemy/__init__.py
+++ b/eve_sqlalchemy/__init__.py
@@ -14,6 +14,8 @@ import flask.ext.sqlalchemy as flask_sqlalchemy
 from flask import abort
 from copy import copy
 
+from eve import Eve
+
 from eve.io.base import ConnectionException
 from eve.io.base import DataLayer
 from eve.utils import config, debug_error_message, str_to_date
@@ -339,3 +341,18 @@ class SQL(DataLayer):
                     'Unable to parse `projection` clause'
                 ))
         return client_projection
+
+
+class EveSqlalchemy(Eve):
+    """
+    EveSqlalchemy
+
+    Code that is typically common for eve-sqlalchemy APIs and/or code that should be upstreamed to
+    eve.
+    """
+    def __init__(self, auth, **kwargs):
+        """
+        We want that the auth object should have access to eve, just like objects of `media` and
+        `data` keywords.
+        """
+        super(EveSqlalchemy, self).__init__(auth=auth(self), **kwargs)

--- a/eve_sqlalchemy/__init__.py
+++ b/eve_sqlalchemy/__init__.py
@@ -6,7 +6,7 @@
     :license: BSD, see LICENSE for more details.
 """
 
-__version__ = '0.1-dev'
+__version__ = '0.4.0a2.dev0'
 
 import simplejson as json
 import flask.ext.sqlalchemy as flask_sqlalchemy

--- a/eve_sqlalchemy/tests/__init__.py
+++ b/eve_sqlalchemy/tests/__init__.py
@@ -19,6 +19,7 @@ EVE = 4
 THIS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
 SETTINGS_FILE = os.path.join(THIS_DIRECTORY, 'test_settings_sql.py')
 
+
 class TestBaseSQL(TestMinimal):
 
     test_sql_tables = test_sql_tables

--- a/eve_sqlalchemy/tests/__init__.py
+++ b/eve_sqlalchemy/tests/__init__.py
@@ -16,6 +16,8 @@ from eve_sqlalchemy import SQL
 
 EVE = 4
 
+THIS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
+SETTINGS_FILE = os.path.join(THIS_DIRECTORY, 'test_settings_sql.py')
 
 class TestBaseSQL(TestMinimal):
 
@@ -24,10 +26,7 @@ class TestBaseSQL(TestMinimal):
     def setUp(self, settings_file=None, url_converters=None):
         self.connection = None
         self.known_resource_count = 101
-        self.this_directory = os.path.dirname(os.path.realpath(__file__))
-        self.settings_file = os.path.join(self.this_directory,
-                                          'test_settings_sql.py')
-        self.app = eve.Eve(settings=self.settings_file,
+        self.app = eve.Eve(settings=SETTINGS_FILE,
                            url_converters=url_converters,
                            data=SQL,
                            validator=ValidatorSQL)

--- a/eve_sqlalchemy/tests/test_constructor.py
+++ b/eve_sqlalchemy/tests/test_constructor.py
@@ -1,0 +1,30 @@
+# -*- coding:utf-8 -*-
+
+import unittest
+
+from eve_sqlalchemy import SQL
+from eve_sqlalchemy import EveSqlalchemy
+
+from eve_sqlalchemy.validation import ValidatorSQL
+
+from eve_sqlalchemy.tests import SETTINGS_FILE
+
+
+class FakeAuth:
+
+    def __init__(self, app):
+        self.app = app
+
+
+class TestConstructor(unittest.TestCase):
+
+    def test_constructor(self):
+        app = EveSqlalchemy(
+            settings=SETTINGS_FILE,
+            validator=ValidatorSQL,
+            data=SQL,
+            auth=FakeAuth,
+        )
+
+        assert isinstance(app.auth, FakeAuth)
+        assert isinstance(app.auth.app, EveSqlalchemy)


### PR DESCRIPTION
Otherwise have to (as far as i can see) do:

```python
app = Eve(
    settings=SETTINGS_PATH,
    validator=ValidatorSQL,
    data=SQL,
    auth=TokenAuth,
)


# NOTE: This is a bit convoluted. TokenAuth needs reference to db.
TokenAuth.app = app
```