### PR TITLE
use DataLayer._client_projection instead of a copy

### DIFF
--- a/eve_sqlalchemy/__init__.py
+++ b/eve_sqlalchemy/__init__.py
@@ -329,6 +329,8 @@ class SQL(DataLayer):
 
         .. versionadded:: 0.4
         """
+        if hasattr(DataLayer, '_client_projection'):
+            return super(SQL, self)._client_projection(req)
         client_projection = {}
         if req and req.projection:
             try:


### PR DESCRIPTION
This patch depends on https://github.com/nicolaiarocci/eve/pulls/724
which move the _client_projection() from the mongodb driver to the
shared DataLayer object.

Eve-SQLAlchemy come with a copy/past of this method, let's us the one
from upstream instead.