### PR TITLE
Fix url field in documentation about additional lookup

### DIFF
--- a/examples/settings.py
+++ b/examples/settings.py
@@ -32,7 +32,7 @@ DOMAIN = {
 DOMAIN['people'].update({
     'item_title': 'person',
     'additional_lookup': {
-        'url': '[0-9]+',
+        'url': 'regex("[0-9]+")',
         'field': 'id'
         },
     'cache_control': 'max-age=10,must-revalidate',


### PR DESCRIPTION
In documentation for additional lookup there is an error in the field
for url. The regex has been badly written.

This closes issue #108.
