### PR TITLE
Added 'Contributing' section to docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,67 @@
+/.project
+/.pydevproject
+/.settings
+.ropeproject
+
+# Eve
+run.py
+settings.py
+
+# Python
+*.py[co]
+
+# Gedit
+*~
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+.eggs
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
 .tox
-*.pyc
-.eggs/
-*.egg-info/
+
+#Translations
+*.mo
+
+#Mr Developer
+.mr.developer.cfg
+
+# SublimeText project files
+*.sublime-*
+
+# vim temp files
+*.swp
+
+#virtualenv
+Include
+Lib
+Scripts
+
+#pyenv
+.python-version
+
+#OSX
+.Python
+.DS_Store
+
+#Sphinx
+_build
+
+# PyCharm
+.idea
+
 .cache

--- a/AUTHORS
+++ b/AUTHORS
@@ -9,14 +9,16 @@ Development Lead
 Patches and Contributions
 `````````````````````````
 
-- Tomasz Jezierski (Tefnet)
+- Alex Kerney
 - Bruce Frederiksen
+- Conrad Burchert
+- David Durieux
+- Dominik Kellner
+- Goneri Le Bouder
 - Jacopo Sabbatini
+- Kevin Roy
+- Leonidaz0r
+- Mario Kralj
 - Nicola Iarocci
 - Peter Zinng
-- Conrad Burchert
-- Leonidaz0r
-- David Durieux
-- Kevin Roy
-- Alex Kerney
-- Goneri Le Bouder
+- Tomasz Jezierski (Tefnet)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,76 @@
+How to Contribute
+#################
+
+Contributions are welcome! Not familiar with the codebase yet? No problem!
+There are many ways to contribute to open source projects: reporting bugs,
+helping with the documentation, spreading the word and of course, adding
+new features and patches. 
+
+Getting Started
+---------------
+#. Make sure you have a GitHub_ account.
+#. Open a `new issue`_, assuming one does not already exist.
+#. Clearly describe the issue including steps to reproduce when it is a bug.
+
+Making Changes
+--------------
+* Fork_ the repository on GitHub.
+* Create a topic branch from where you want to base your work.
+* This is usually the ``develop`` branch. 
+* Please avoid working directly on the ``develop`` branch.
+* Make commits of logical units (if needed rebase your feature branch before
+  submitting it).
+* Check for unnecessary whitespace with ``git diff --check`` before committing.
+* Make sure your commit messages are in the `proper format`_.
+* If your commit fixes an open issue, reference it in the commit message (#15).
+* Make sure your code conforms to PEP8_ (we're using flake8_ for PEP8 and extra checks).
+* Make sure you have added the necessary tests for your changes.
+* Run all the tests to assure nothing else was accidentally broken.
+* Run again the entire suite via tox_ to check your changes against multiple
+  python versions. ``pip install tox; tox``
+* Don't forget to add yourself to AUTHORS_.
+
+These guidelines also apply when helping with documentation (actually,
+for typos and minor additions you might choose to `fork and
+edit`_).
+
+Submitting Changes
+------------------
+* Push your changes to a topic branch in your fork of the repository.
+* Submit a `Pull Request`_.
+* Wait for maintainer feedback.
+
+Join us on IRC and/or Gitter
+----------------------------
+If you're interested in contributing to the Eve-SQLAlchemy project or have any
+questions about it, come join us in Eve's #python-eve channel on
+irc.freenode.net or Eve-SQLAlchemy `gitter`_ room.
+
+First time contributor?
+-----------------------
+It's alright. We've all been there. See next chapter.
+
+Don't know where to start? 
+--------------------------
+There are usually several TODO comments scattered around the codebase, maybe
+check them out and see if you have ideas, or can help with them. Also, check
+the `open issues`_ in case there's something that sparks your interest. If
+you're fluent in English (or notice any typo and/or mistake), feel free to
+improve the documentation. In any case, other than GitHub help_ pages, you might
+want to check this excellent `Effective Guide to Pull Requests`_
+
+.. _`the repository`: https://github.com/RedTurtle/eve-sqlalchemy
+.. _AUTHORS: https://github.com/RedTurtle/eve-sqlalchemy/blob/develop/AUTHORS
+.. _`open issues`: https://github.com/RedTurtle/eve-sqlalchemy/issues
+.. _`new issue`: https://github.com/RedTurtle/eve-sqlalchemy/issues/new
+.. _GitHub: https://github.com/
+.. _Fork: https://help.github.com/articles/fork-a-repo
+.. _`proper format`: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
+.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+.. _flake8: http://flake8.readthedocs.org/en/latest/
+.. _tox: http://tox.readthedocs.org/en/latest/
+.. _help: https://help.github.com/
+.. _`Effective Guide to Pull Requests`: http://codeinthehole.com/writing/pull-requests-and-other-good-practices-for-teams-using-github/
+.. _`fork and edit`: https://github.com/blog/844-forking-with-the-edit-button
+.. _`Pull Request`: https://help.github.com/articles/creating-a-pull-request
+.. _`gitter`: https://gitter.im/RedTurtle/eve-sqlalchemy

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,3 @@
+.. _contributing:
+
+.. include:: ../CONTRIBUTING.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Developer's Guide
 
     tutorial
     trivial
+    contributing
 
 .. include:: ../CHANGES
 


### PR DESCRIPTION
As mentioned in #128, documentation is updated with "Contributing" section. I followed file structure like in Eve documentation. Eve related links are changed to point to Eve-SQLAlchemy repository and information about running tests is omitted since we still miss this section. I would add it but I think this is a bit different topic at the moment.
I added information about Gitter room and IRC channel (although it is Eve channel) because I usually hang around there and I'm willing to help there if necessary.
I also updated `.gitignore` and sorted people names in `AUTHORS` alphabetically (even added @dkellner in the list ;)).