### PR TITLE
Leverage further automated syntax and formatting checks

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,7 +50,8 @@ Changelog
 0.3.2 (2015-05-01)
 ~~~~~~~~~~~~~~~~~~
 
-- add fallback on attr.op if the operator doesn't exists in the `ColumnProperty` [Kevin Roy]
+- add fallback on attr.op if the operator doesn't exists in the
+  `ColumnProperty` [Kevin Roy]
 - add support for PostgreSQL JSON type [Goneri Le Bouder]
 
 
@@ -63,7 +64,8 @@ Changelog
 0.3 (2015-04-17)
 ~~~~~~~~~~~~~~~~
 
-- return everything as dicts instead of SQLAResult, remove SQLAResult [Leonidaz0r]
+- return everything as dicts instead of SQLAResult, remove SQLAResult
+  [Leonidaz0r]
 - fix update function, this closes #22 [David Durieux]
 - fixed replaced method, we are compatible with Eve>=0.5.1 [Kevin Roy]
 - fixed jsonify function [Leonidaz0r]
@@ -82,9 +84,9 @@ Changelog
 ~~~~~~~~~~~~~~~~
 
 - various bugfixing [Arie Brosztein, toxsick]
-- refactor sorting parser, add sql order by expresssions;
-  please check http://eve-sqlalchemy.readthedocs.org/#sqlalchemy-sorting 
-  for more details [amleczko]
+- refactor sorting parser, add sql order by expresssions; please check
+  http://eve-sqlalchemy.readthedocs.org/#sqlalchemy-sorting for more details
+  [amleczko]
 
 
 0.1 (2015-01-13)

--- a/CHANGES
+++ b/CHANGES
@@ -4,7 +4,7 @@ Changelog
 0.4.2 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
-- Nothing changed yet.
+- Leverage further automated syntax and formatting checks. [Dominik Kellner]
 
 
 0.4.1 (2015-12-16)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,7 +14,7 @@ Getting Started
 
 Making Changes
 --------------
-* Fork_ the repository on GitHub.
+* Fork_ the repository_ on GitHub.
 * Create a topic branch from where you want to base your work.
 * This is usually the ``master`` branch.
 * Please avoid working directly on the ``master`` branch.
@@ -60,7 +60,7 @@ you're fluent in English (or notice any typo and/or mistake), feel free to
 improve the documentation. In any case, other than GitHub help_ pages, you might
 want to check this excellent `Effective Guide to Pull Requests`_
 
-.. _`the repository`: https://github.com/RedTurtle/eve-sqlalchemy
+.. _repository: https://github.com/RedTurtle/eve-sqlalchemy
 .. _AUTHORS: https://github.com/RedTurtle/eve-sqlalchemy/blob/master/AUTHORS
 .. _`open issues`: https://github.com/RedTurtle/eve-sqlalchemy/issues
 .. _`new issue`: https://github.com/RedTurtle/eve-sqlalchemy/issues/new

--- a/README.rst
+++ b/README.rst
@@ -4,19 +4,15 @@ Eve SQLAlchemy extension
 .. image:: https://travis-ci.org/RedTurtle/eve-sqlalchemy.svg?branch=master
    :target: https://travis-ci.org/RedTurtle/eve-sqlalchemy
 
-
 .. image:: https://coveralls.io/repos/RedTurtle/eve-sqlalchemy/badge.svg?branch=master
    :target: https://coveralls.io/r/RedTurtle/eve-sqlalchemy?branch=master
-
 
 .. image:: https://landscape.io/github/RedTurtle/eve-sqlalchemy/master/landscape.svg?style=flat
    :target: https://landscape.io/github/RedTurtle/eve-sqlalchemy/master
 
-
-
-Powered by Eve, SQLAlchemy and good intentions this extenstion allows to 
-effortlessly build and deploy highly customizable, fully featured RESTful Web 
-Services with SQL-based backends.
+Powered by Eve, SQLAlchemy and good intentions this extenstion allows
+to effortlessly build and deploy highly customizable, fully featured
+RESTful Web Services with SQL-based backends.
 
 Eve SQLAlchemy is Simple
 ------------------------
@@ -35,9 +31,10 @@ The API is now live, ready to be consumed:
     $ curl -i http://example.com/people
     HTTP/1.1 200 OK
 
-All you need to bring your API online is a database, a configuration file
-(defaults to ``settings.py``) and a launch script.  Overall, you will find that
-configuring and fine-tuning your API is a very simple process.
+All you need to bring your API online is a database, a configuration
+file (defaults to ``settings.py``) and a launch script.  Overall, you
+will find that configuring and fine-tuning your API is a very simple
+process.
 
 Eve is thoroughly tested under Python 2.6, 2.7, 3.3, 3.4 and PyPy.
 
@@ -46,3 +43,4 @@ Make sure you check both these websites:
 - `Official Eve Website <http://python-eve.org/>`_
 - `Eve-SQLAlchemy Tutorials and Howtos <http://eve-sqlalchemy.readthedocs.org/>`_
 
+\

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,3 +1,1 @@
-.. _contributing:
-
 .. include:: ../CONTRIBUTING.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,3 @@
-.. _sqlalchemy_support:
-
 SQLAlchemy support
 ==================
 

--- a/docs/trivial.rst
+++ b/docs/trivial.rst
@@ -1,5 +1,3 @@
-.. _trivial_example:
-
 Simple example
 ==============
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,5 +1,3 @@
-.. _tutorial:
-
 Tutorial
 ========
 The example app used by this tutorial is available at ``examples`` inside
@@ -7,15 +5,16 @@ the Eve-SQLAlchemy repository.
 
 Schema registration
 -------------------
-The main goal of the `SQLAlchemy`_ integration in Eve is to separate dependencies
-and keep model registration depend only on sqlalchemy library. This means that
-you can simply use something like that:
+The main goal of the `SQLAlchemy`_ integration in Eve is to separate
+dependencies and keep model registration depend only on sqlalchemy
+library. This means that you can simply use something like that:
 
 .. literalinclude:: ../examples/tables.py
    :lines: 6-19,34-40,46-
 
-We have used ``CommonColumns`` abstract class to provide attributes used by Eve,
-such us ``_created`` and ``_updated``, but you are not forced to used them:
+We have used ``CommonColumns`` abstract class to provide attributes used by
+Eve, such us ``_created`` and ``_updated``, but you are not forced to used
+them:
 
 .. literalinclude:: ../examples/tables.py
    :lines: 20-24
@@ -23,16 +22,16 @@ such us ``_created`` and ``_updated``, but you are not forced to used them:
 
 Eve settings
 ------------
-All standard Eve settings will work with `SQLAlchemy`_ support. However, you need
-manually decide which `SQLAlchemy`_ declarative classes you wish to register.
-You can do it using ``registerSchema``:
+All standard Eve settings will work with `SQLAlchemy`_ support. However, you
+need manually decide which `SQLAlchemy`_ declarative classes you wish to
+register.  You can do it using ``registerSchema``:
 
 .. literalinclude:: ../examples/settings.py
    :lines: 9-13, 25-29
 
 As you noticed the schema will be stored inside `_eve_schema` class attribute
-so it can be easily used. You can of course extend the autogenerate schema
-with your custom options:
+so it can be easily used. You can of course extend the autogenerate schema with
+your custom options:
 
 .. literalinclude:: ../examples/settings.py
    :lines: 31-
@@ -44,8 +43,6 @@ This example is based on the Token-Based tutorial from `Eve Authentication`_.
 First we need to create eve-side authentication:
 
 .. code-block:: python
-
-    # -*- coding: utf-8 -*-
 
     """
     Auth-Token
@@ -86,8 +83,6 @@ First we need to create eve-side authentication:
 Next step is the `User` SQLAlchemy model:
 
 .. code-block:: python
-
-    # -*- coding: utf-8 -*-
 
     """
     Auth-Token
@@ -177,8 +172,6 @@ And finally a flask login view:
 
 .. code-block:: python
 
-    # -*- coding: utf-8 -*-
-
     """
     Auth-Token
     ~~~~~~~~~~
@@ -241,7 +234,8 @@ and start it:
     $ python sqla_example.py
      * Running on http://127.0.0.1:5000/
 
-and check that everything is working like expected, by trying requesting `people`:
+and check that everything is working like expected, by trying requesting
+`people`:
 
 .. code-block:: console
 
@@ -297,8 +291,8 @@ SQLAlchemy expressions
 With this version of Eve you can use `SQLAlchemy`_ expressions such as: `like`,
 `in`, `any`, etc. For more examples please check `SQLAlchemy internals`_.
 
-Using those expresssion is straightforward (you can use them only with dictionary
-where filter):
+Using those expresssion is straightforward (you can use them only with
+dictionary where filter):
 
 .. code-block:: console
 
@@ -360,10 +354,11 @@ which produces where closure:
 
 SQLAlchemy sorting
 ------------------
-Starting from version 0.2 you can use `SQLAlchemy ORDER BY`_ expressions such as: `nullsfirst`,
-`nullslast`, etc.
+Starting from version 0.2 you can use `SQLAlchemy ORDER BY`_ expressions such
+as: `nullsfirst`, `nullslast`, etc.
 
-Using those expresssion is straightforward, just pass it as 3 argument to sorting:
+Using those expresssion is straightforward, just pass it as 3 argument to
+sorting:
 
 .. code-block:: console
 
@@ -384,9 +379,9 @@ You can also support the following python-Eve syntax:
 How to adjust the primary column name
 -------------------------------------
 
-Eve use the `_id` column as primary id field. This is the default value of the MongoDB database.
-In SQL, it much more common to call this column just `id`. You can do that with the following
-change in your `settings.py`:
+Eve use the `_id` column as primary id field. This is the default value of the
+MongoDB database.  In SQL, it much more common to call this column just
+`id`. You can do that with the following change in your `settings.py`:
 
 .. code-block:: python
 
@@ -406,17 +401,20 @@ change in your `settings.py`:
 Embedded resources
 ------------------
 
-Eve-SQLAlchemy support the embedded keyword of python-eve ( `Eve Embedded Resource Serialization`_ ).
+Eve-SQLAlchemy support the embedded keyword of python-eve (`Eve Embedded
+Resource Serialization`_).
 
 .. code-block:: console
 
     http://127.0.0.1:5000/people?embedded={"address":1}
 
-For example, the following request will list the people and embedded their addresses.
+For example, the following request will list the people and embedded their
+addresses.
 
-Starting from version 0.4.0a, only the fields that have the projection (`Eve Projections`) enabled are included
-in the associated resource. This was necessary to avoid endless loop when relationship between resources were
-refeering each others.
+Starting from version 0.4.0a, only the fields that have the projection (`Eve
+Projections`_) enabled are included in the associated resource. This was
+necessary to avoid endless loops when relationship between resources were
+referring each other.
 
 
 .. _SQLAlchemy: http://www.sqlalchemy.org/

--- a/eve_sqlalchemy/__init__.py
+++ b/eve_sqlalchemy/__init__.py
@@ -268,8 +268,8 @@ class SQL(DataLayer):
     def replace(self, resource, id_, document, original):
         model, filter_, fields_, _ = self._datasource_ex(resource, [])
         id_field = self._id_field(resource)
-        filter_ = self.combine_queries(filter_,
-                                       parse_dictionary({id_field: id_}, model))
+        filter_ = self.combine_queries(
+            filter_, parse_dictionary({id_field: id_}, model))
         query = self.driver.session.query(model)
 
         # Find and delete the old object
@@ -289,8 +289,8 @@ class SQL(DataLayer):
     def update(self, resource, id_, updates, original):
         model, filter_, _, _ = self._datasource_ex(resource, [])
         id_field = self._id_field(resource)
-        filter_ = self.combine_queries(filter_,
-                                       parse_dictionary({id_field: id_}, model))
+        filter_ = self.combine_queries(
+            filter_, parse_dictionary({id_field: id_}, model))
         query = self.driver.session.query(model)
         model_instance = query.filter(*filter_).first()
         if model_instance is None:

--- a/eve_sqlalchemy/__init__.py
+++ b/eve_sqlalchemy/__init__.py
@@ -8,20 +8,21 @@
 from __future__ import unicode_literals
 
 import collections
-import simplejson as json
-import flask.ext.sqlalchemy as flask_sqlalchemy
-
-from flask import abort
 from copy import copy
 
-from eve.io.base import ConnectionException
-from eve.io.base import DataLayer
+import flask.ext.sqlalchemy as flask_sqlalchemy
+import simplejson as json
+from eve.io.base import ConnectionException, DataLayer
 from eve.utils import config, debug_error_message, str_to_date
-from .parser import parse, parse_dictionary, ParseError, sqla_op, parse_sorting
+from flask import abort
+
+from .parser import ParseError, parse, parse_dictionary, parse_sorting, sqla_op
 from .structures import SQLAResultCollection
-from .utils import dict_update, validate_filters, sqla_object_to_dict, \
-    extract_sort_arg, rename_relationship_fields_in_sort_args, \
-    rename_relationship_fields_in_dict, rename_relationship_fields_in_str
+from .utils import (
+    dict_update, extract_sort_arg, rename_relationship_fields_in_dict,
+    rename_relationship_fields_in_sort_args, rename_relationship_fields_in_str,
+    sqla_object_to_dict, validate_filters,
+)
 
 __version__ = '0.1-dev'
 

--- a/eve_sqlalchemy/decorators.py
+++ b/eve_sqlalchemy/decorators.py
@@ -7,14 +7,13 @@
 """
 from __future__ import unicode_literals
 
-from sqlalchemy.sql import expression
-from sqlalchemy.ext.hybrid import HYBRID_PROPERTY
-from sqlalchemy.ext.associationproxy import ASSOCIATION_PROXY
-from sqlalchemy.orm.attributes import InstrumentedAttribute
-from sqlalchemy import types, inspect
 import sqlalchemy.dialects.postgresql as postgresql
-from sqlalchemy import schema as sqla_schema
 from eve.utils import config
+from sqlalchemy import inspect, schema as sqla_schema, types
+from sqlalchemy.ext.associationproxy import ASSOCIATION_PROXY
+from sqlalchemy.ext.hybrid import HYBRID_PROPERTY
+from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.sql import expression
 
 from .utils import dict_update
 

--- a/eve_sqlalchemy/media.py
+++ b/eve_sqlalchemy/media.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-from io import BytesIO
-
 """
-    Media storage for sqlalchemy extenstion.
+    Media storage for sqlalchemy extension.
 
     :copyright: (c) 2014 by Andrew Mleczko
     :license: BSD, see LICENSE for more details.
 """
+from __future__ import unicode_literals
+
+from io import BytesIO
 
 
 class SQLBlobMediaStorage(object):

--- a/eve_sqlalchemy/parser.py
+++ b/eve_sqlalchemy/parser.py
@@ -9,14 +9,14 @@
 """
 from __future__ import unicode_literals
 
-import re
 import ast
-import operator as sqla_op
-import json
 import itertools
+import json
+import operator as sqla_op
+import re
 
-from eve.utils import str_to_date
 import sqlalchemy
+from eve.utils import str_to_date
 from sqlalchemy.ext.associationproxy import AssociationProxy
 from sqlalchemy.sql import expression as sqla_exp
 

--- a/eve_sqlalchemy/tests/__init__.py
+++ b/eve_sqlalchemy/tests/__init__.py
@@ -11,14 +11,16 @@ original Eve test code.
 from __future__ import unicode_literals
 
 import collections
-import random
 import os
+import random
+
 import eve
 import eve.tests
 from eve import ISSUES
+
+import eve_sqlalchemy.tests.test_sql_tables  # noqa
 from eve_sqlalchemy import SQL
 from eve_sqlalchemy.validation import ValidatorSQL
-import eve_sqlalchemy.tests.test_sql_tables  # noqa
 
 
 class TestMinimal(eve.tests.TestMinimal):

--- a/eve_sqlalchemy/tests/delete.py
+++ b/eve_sqlalchemy/tests/delete.py
@@ -2,10 +2,10 @@
 from __future__ import unicode_literals
 
 import pytest
-
 from eve import ETAG
 from eve.tests.methods import delete as eve_delete_tests
 from eve.tests.utils import DummyEvent
+
 from eve_sqlalchemy.tests import TestBase
 
 

--- a/eve_sqlalchemy/tests/get.py
+++ b/eve_sqlalchemy/tests/get.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import time
+
 import pytest
 import simplejson as json
-import time
 from eve.tests.methods import get as eve_get_tests
+
 from eve_sqlalchemy.tests import TestBase
 
 

--- a/eve_sqlalchemy/tests/patch.py
+++ b/eve_sqlalchemy/tests/patch.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import pytest
 from eve import ETAG
 from eve.tests.methods import patch as eve_patch_tests
+
 from eve_sqlalchemy.tests import TestBase
 
 

--- a/eve_sqlalchemy/tests/post.py
+++ b/eve_sqlalchemy/tests/post.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import pytest
 from eve import ISSUES, STATUS
 from eve.tests.methods import post as eve_post_tests
+
 from eve_sqlalchemy.tests import TestBase, test_sql_tables
 
 

--- a/eve_sqlalchemy/tests/put.py
+++ b/eve_sqlalchemy/tests/put.py
@@ -5,6 +5,7 @@ import pytest
 import six
 from eve import ETAG, STATUS
 from eve.tests.methods import put as eve_put_tests
+
 from eve_sqlalchemy.tests import TestBase
 
 

--- a/eve_sqlalchemy/tests/sql.py
+++ b/eve_sqlalchemy/tests/sql.py
@@ -1,24 +1,23 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import random
 import os
+import random
 import string
-import eve
 from datetime import datetime
-from unittest import TestCase
-from sqlalchemy.sql.elements import BooleanClauseList
 from operator import and_, or_
-from eve.utils import str_to_date
-from eve_sqlalchemy.tests.test_sql_tables import Contacts
-from eve_sqlalchemy.parser import parse
-from eve_sqlalchemy.parser import parse_dictionary
-from eve_sqlalchemy.parser import parse_sorting
-from eve_sqlalchemy.parser import ParseError
-from eve_sqlalchemy.parser import sqla_op
+from unittest import TestCase
 
-from eve_sqlalchemy.structures import SQLAResultCollection
+import eve
+from eve.utils import str_to_date
+from sqlalchemy.sql.elements import BooleanClauseList
+
 from eve_sqlalchemy import SQL
+from eve_sqlalchemy.parser import (
+    ParseError, parse, parse_dictionary, parse_sorting, sqla_op,
+)
+from eve_sqlalchemy.structures import SQLAResultCollection
+from eve_sqlalchemy.tests.test_sql_tables import Contacts
 
 
 class TestSQLParser(TestCase):

--- a/eve_sqlalchemy/tests/sql.py
+++ b/eve_sqlalchemy/tests/sql.py
@@ -159,8 +159,8 @@ class TestSQLParser(TestCase):
         self.assertEqual(r[0].right.value,
                          "('john','mark')")
 
-        r = parse_dictionary({'username': 'similar to("(\'john%\'|\'mark%\')")'},
-                             self.model)
+        r = parse_dictionary(
+            {'username': 'similar to("(\'john%\'|\'mark%\')")'}, self.model)
         self.assertEqual(str(r[0]),
                          'contacts.username similar to :username_1')
         self.assertEqual(r[0].right.value,
@@ -226,11 +226,11 @@ class TestSQLStructures(TestCase):
         self.assertEqual(str(
             parse_sorting(Contacts, self.query, 'username', 1)).lower(),
             'contacts.username')
-        self.assertEqual(str(
-            parse_sorting(Contacts, self.query, 'username', -1, 'nullslast')).lower(),
+        self.assertEqual(str(parse_sorting(
+            Contacts, self.query, 'username', -1, 'nullslast')).lower(),
             'contacts.username desc nulls last')
-        self.assertEqual(str(
-            parse_sorting(Contacts, self.query, 'username', -1, 'nullsfirst')).lower(),
+        self.assertEqual(str(parse_sorting(
+            Contacts, self.query, 'username', -1, 'nullsfirst')).lower(),
             'contacts.username desc nulls first')
 
     def setupDB(self):

--- a/eve_sqlalchemy/tests/test_settings.py
+++ b/eve_sqlalchemy/tests/test_settings.py
@@ -165,7 +165,8 @@ products = {
     'item_url': 'regex("[A-Z]+")'
 }
 child_products = copy.deepcopy(products)
-child_products['url'] = 'products/<regex("[A-Z]+"):parent_product_sku>/children'
+child_products['url'] = \
+    'products/<regex("[A-Z]+"):parent_product_sku>/children'
 child_products['datasource'] = {'source': 'Products'}
 
 DOMAIN = {

--- a/eve_sqlalchemy/tests/test_settings.py
+++ b/eve_sqlalchemy/tests/test_settings.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+
 import copy
 
 # db_filename = os.path.join(os.path.dirname(os.path.realpath(__file__)),

--- a/eve_sqlalchemy/tests/test_sql_tables.py
+++ b/eve_sqlalchemy/tests/test_sql_tables.py
@@ -2,21 +2,17 @@
 from __future__ import unicode_literals
 
 import hashlib
-from sqlalchemy.ext.declarative import declarative_base
+
+from sqlalchemy import (
+    Boolean, Column, DateTime, Float, ForeignKey, Integer, LargeBinary,
+    PickleType, String, func,
+)
 from sqlalchemy.ext.associationproxy import association_proxy
+from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
-from sqlalchemy import Column
-from sqlalchemy import Boolean
-from sqlalchemy import DateTime
-from sqlalchemy import ForeignKey
-from sqlalchemy import func
-from sqlalchemy import Integer
-from sqlalchemy import Float
-from sqlalchemy import String
-from sqlalchemy import LargeBinary
-from sqlalchemy import PickleType
-from eve_sqlalchemy.decorators import registerSchema
+
 from eve_sqlalchemy import db
+from eve_sqlalchemy.decorators import registerSchema
 
 Base = declarative_base()
 db.Model = Base

--- a/eve_sqlalchemy/tests/test_validation.py
+++ b/eve_sqlalchemy/tests/test_validation.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 import unittest
+
 import eve_sqlalchemy.validation
 
 

--- a/eve_sqlalchemy/tests/test_validation_allow_unknown.py
+++ b/eve_sqlalchemy/tests/test_validation_allow_unknown.py
@@ -2,9 +2,11 @@
 from __future__ import unicode_literals
 
 import unittest
+
+from eve.utils import config
+
 import eve_sqlalchemy.validation
 from eve_sqlalchemy.tests.test_settings import DOMAIN
-from eve.utils import config
 
 
 class TestValidator(unittest.TestCase):

--- a/eve_sqlalchemy/tests/test_validation_allow_unknown.py
+++ b/eve_sqlalchemy/tests/test_validation_allow_unknown.py
@@ -19,7 +19,8 @@ class TestValidator(unittest.TestCase):
             'allow_unknown': True,
         })
         config.DOMAIN = DOMAIN
-        self.validator = eve_sqlalchemy.validation.ValidatorSQL(schemas, resource='contacts')
+        self.validator = eve_sqlalchemy.validation.ValidatorSQL(
+            schemas, resource='contacts')
 
     def test_allow_unknown_true(self):
         self.assertTrue(self.validator.allow_unknown)

--- a/eve_sqlalchemy/tests/utils.py
+++ b/eve_sqlalchemy/tests/utils.py
@@ -2,7 +2,9 @@
 from __future__ import unicode_literals
 
 import unittest
+
 import mock
+
 from eve_sqlalchemy.utils import extract_sort_arg
 
 

--- a/eve_sqlalchemy/tests/utils.py
+++ b/eve_sqlalchemy/tests/utils.py
@@ -16,7 +16,8 @@ class TestUtils(unittest.TestCase):
     def test_extract_sort_arg_sqlalchemy(self):
         req = mock.Mock()
         req.sort = '[("created_at", -1, "nullstart")]'
-        self.assertEqual(extract_sort_arg(req), [('created_at', -1, 'nullstart')])
+        self.assertEqual(extract_sort_arg(req),
+                         [('created_at', -1, 'nullstart')])
 
     def test_extract_sort_arg_null(self):
         req = mock.Mock()

--- a/eve_sqlalchemy/validation.py
+++ b/eve_sqlalchemy/validation.py
@@ -5,7 +5,8 @@
     conform to the API domain.
     An extension of Cerberus Validator.
 
-    :copyright: (c) 2013 by Nicola Iarocci, Andrew Mleczko and Tomasz Jezierski (Tefnet)
+    :copyright: (c) 2013 by Nicola Iarocci, Andrew Mleczko and
+                Tomasz Jezierski (Tefnet)
     :license: BSD, see LICENSE for more details.
 """
 from __future__ import unicode_literals

--- a/eve_sqlalchemy/validation.py
+++ b/eve_sqlalchemy/validation.py
@@ -13,12 +13,14 @@ from __future__ import unicode_literals
 
 import collections
 import copy
+
 from cerberus import Validator
-from flask import current_app as app
 from eve.utils import config, str_type
 from eve.versioning import (
-    get_data_version_relation_document,
-    missing_version_field)
+    get_data_version_relation_document, missing_version_field,
+)
+from flask import current_app as app
+
 from eve_sqlalchemy.utils import dict_update, remove_none_values
 
 

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -6,8 +6,10 @@
     Mongo as we need to define the schema using the registerSchema decorator.
 """
 from eve.utils import config
+
 from eve_sqlalchemy.decorators import registerSchema
-from tables import People, Invoices
+
+from .tables import Invoices, People
 
 ID_FIELD = 'id'
 config.ID_FIELD = ID_FIELD

--- a/examples/settings.py
+++ b/examples/settings.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 """
-    Normal settings file for Eve.
+    Settings file for Eve.
 
-    Differently from a configuration file for an Eve application backed by Mongo
-    we need to define the schema using the registerSchema decorator.
-
+    Different from a configuration file for an Eve application backed by
+    Mongo as we need to define the schema using the registerSchema decorator.
 """
 from eve.utils import config
 from eve_sqlalchemy.decorators import registerSchema
@@ -20,8 +19,9 @@ registerSchema('invoices')(Invoices)
 
 SQLALCHEMY_DATABASE_URI = 'sqlite://'
 
-# The following two lines will output the SQL statements executed by SQLAlchemy.
-# Useful while debugging and in development. Turned off by default
+# The following two lines will output the SQL statements executed by
+# SQLAlchemy. This is useful while debugging and in development, but is turned
+# off by default.
 # --------
 # SQLALCHEMY_ECHO = True
 # SQLALCHEMY_RECORD_QUERIES = True

--- a/examples/sqla_example.py
+++ b/examples/sqla_example.py
@@ -18,4 +18,5 @@ if not db.session.query(People).count():
         db.session.add(People.from_tuple(item))
     db.session.commit()
 
-app.run(debug=True, use_reloader=False)  # using reloaded will destory in-memory sqlite db
+# using reloader will destroy in-memory sqlite db
+app.run(debug=True, use_reloader=False)

--- a/examples/sqla_example.py
+++ b/examples/sqla_example.py
@@ -1,7 +1,9 @@
 from eve import Eve
+
 from eve_sqlalchemy import SQL
 from eve_sqlalchemy.validation import ValidatorSQL
-from tables import People, Base
+
+from .tables import Base, People
 
 app = Eve(validator=ValidatorSQL, data=SQL)
 

--- a/examples/tables.py
+++ b/examples/tables.py
@@ -3,15 +3,9 @@
     This is a typical declarative usage of sqlalchemy,
     It has no dependency on flask or eve iself. Pure sqlalchemy.
 """
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import column_property, relationship
-from sqlalchemy import func
-from sqlalchemy import (
-    Column,
-    String,
-    Integer,
-    ForeignKey,
-    DateTime)
 
 Base = declarative_base()
 

--- a/examples/trivial.py
+++ b/examples/trivial.py
@@ -1,16 +1,12 @@
 ''' Trivial Eve-SQLAlchemy example. '''
-# SQLAlchemy Imports
+from eve import Eve
+from sqlalchemy import Column, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import column_property
-from sqlalchemy import Column, Integer, String
 
-# Eve imports
-from eve import Eve
 from eve_sqlalchemy import SQL
-from eve_sqlalchemy.validation import ValidatorSQL
-
-# Eve-SQLAlchemy imports
 from eve_sqlalchemy.decorators import registerSchema
+from eve_sqlalchemy.validation import ValidatorSQL
 
 Base = declarative_base()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,15 @@
 [flake8]
 exclude = build,docs,.git,.tox
 
+[isort]
+combine_as_imports = true
+default_section = THIRDPARTY
+include_trailing_comma = true
+known_first_party = eve_sqlalchemy
+line_length = 79
+multi_line_output = 5
+not_skip = __init__.py
+
 [tool:pytest]
 python_files = eve_sqlalchemy/tests/*.py
 addopts = -rf

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,6 @@
 max-line-length = 160
 
 [tool:pytest]
-python_files=eve_sqlalchemy/tests/*.py
+python_files = eve_sqlalchemy/tests/*.py
 addopts = -rf
 norecursedirs = testsuite .tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 160
+exclude = build,docs,.git,.tox
 
 [tool:pytest]
 python_files = eve_sqlalchemy/tests/*.py

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     py{26,27,33,34,35,36},
     flake8,
-    isort
+    isort,
+    rstcheck
 
 [testenv]
 deps = .[test]
@@ -15,3 +16,7 @@ commands = flake8 .
 [testenv:isort]
 deps = isort
 commands = isort --recursive --check-only --diff eve_sqlalchemy examples
+
+[testenv:rstcheck]
+deps = rstcheck
+commands = /bin/sh -c "rstcheck docs/*.rst *.rst"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,7 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,py36,flake8
+envlist =
+    py{26,27,33,34,35,36},
+    flake8
 
 [testenv]
 deps = .[test]
@@ -7,5 +9,4 @@ commands = py.test {posargs}
 
 [testenv:flake8]
 deps = flake8
-basepython = python2.7
-commands = flake8 {posargs} eve_sqlalchemy examples
+commands = flake8 .

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist=py26,py27,py33,py34,py35,py36,flake8
+envlist = py26,py27,py33,py34,py35,py36,flake8
 
 [testenv]
-deps=.[test]
-commands=py.test {posargs}
+deps = .[test]
+commands = py.test {posargs}
 
 [testenv:flake8]
-deps=flake8
-basepython=python2.7
-commands=flake8 {posargs} eve_sqlalchemy examples
+deps = flake8
+basepython = python2.7
+commands = flake8 {posargs} eve_sqlalchemy examples

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist =
     py{26,27,33,34,35,36},
     flake8,
     isort,
-    rstcheck
+    rstcheck,
+    whitespace
 
 [testenv]
 deps = .[test]
@@ -20,3 +21,7 @@ commands = isort --recursive --check-only --diff eve_sqlalchemy examples
 [testenv:rstcheck]
 deps = rstcheck
 commands = /bin/sh -c "rstcheck docs/*.rst *.rst"
+
+[testenv:whitespace]
+deps = flake8
+commands = /bin/sh -c "flake8 --select=W1,W2,W3 docs/*.rst *"

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
     py{26,27,33,34,35,36},
-    flake8
+    flake8,
+    isort
 
 [testenv]
 deps = .[test]
@@ -10,3 +11,7 @@ commands = py.test {posargs}
 [testenv:flake8]
 deps = flake8
 commands = flake8 .
+
+[testenv:isort]
+deps = isort
+commands = isort --recursive --check-only --diff eve_sqlalchemy examples


### PR DESCRIPTION
- configure `flake8` to adhere to a more "standard" configuration
- add `isort` to check import order
- add `rstcheck` to check .rst-files
- use `flake8` to check whitespace of non-Python files